### PR TITLE
Handle ALL anywhere in export flag

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -114,8 +114,8 @@ def main():
 
     # If --export was given, check whether it already contains ALL, if not, add
     if args.export:
-        if not re.match(r'\bALL\b', args.export):
-            args.export  = 'ALL,' + args.export
+        if not re.search(r'\bALL\b', args.export):
+            args.export = 'ALL,' + args.export
     else:
         args.export = 'ALL'
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import cbatch
+
+
+def test_export_all_suffix(tmp_path, capsys, monkeypatch):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    monkeypatch.setattr(sys, "argv", [
+        "cbatch",
+        "--cluster",
+        "foo",
+        "--dry-run",
+        "--export",
+        "VAR=1,ALL",
+        str(script),
+    ])
+    cbatch.main()
+    out = capsys.readouterr().out
+    assert "--export=VAR=1,ALL" in out
+    assert "--export=ALL,VAR=1,ALL" not in out


### PR DESCRIPTION
## Summary
- check for `ALL` anywhere in `--export` instead of only at start
- add regression test for export strings containing `ALL` later in the value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932a5c44248329b305134e0ee9b026

## Summary by Sourcery

Support ALL anywhere in the --export flag and prevent duplicate ALL entries

Enhancements:
- Use search instead of match to detect ALL anywhere in the export string

Tests:
- Add regression test to ensure ALL is not prepended when it appears later in the export value