### PR TITLE
Validate modules file path

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -103,6 +103,11 @@ def main():
     # that were set as directives in the job script
     args, sbatch_args = parser.parse_known_args(namespace=script_args)
 
+    # If a modules file was specified, ensure that it exists
+    if args.modules and not pathlib.Path(args.modules).is_file():
+        print(f"Error: modules file '{args.modules}' not found", file=sys.stderr)
+        sys.exit(1)
+
     # If no --cluster was given, exit
     if not args.cluster:
         print('Error: no cluster specified', file=sys.stderr)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import cbatch
+
+
+def test_missing_modules_file(tmp_path, capsys, monkeypatch):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    missing = tmp_path / "missing.txt"
+    monkeypatch.setattr(sys, "argv", [
+        "cbatch",
+        "--cluster",
+        "foo",
+        "--modules",
+        str(missing),
+        str(script),
+    ])
+    with pytest.raises(SystemExit) as excinfo:
+        cbatch.main()
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "modules file" in err
+    assert str(missing) in err


### PR DESCRIPTION
## Summary
- ensure `--modules` file path exists before submitting the job
- add regression test for missing modules file

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932dd9369c8329bbaf0c5f29153df4

## Summary by Sourcery

Validate modules file existence in cbatch.main and add a test to catch missing modules file errors.

New Features:
- Validate that the --modules file path exists before submitting a job

Tests:
- Add regression test to ensure missing modules file triggers an error and exits with code 1