### PR TITLE
Handle FileNotFoundError exit code in cbatch

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -176,7 +176,7 @@ def main():
         sys.exit(exit_status)
     except FileNotFoundError as e:
         print(f'Error: {e}', file=sys.stderr)
-        sys.exit(e.returncode)
+        sys.exit(e.errno or 1)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
     except KeyboardInterrupt:

--- a/tests/test_file_not_found.py
+++ b/tests/test_file_not_found.py
@@ -1,0 +1,26 @@
+import sys
+import subprocess
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import cbatch
+
+
+def test_file_not_found_exit_code(tmp_path, monkeypatch, capsys):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+
+    def fake_popen(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(sys, "argv", ["cbatch", "--cluster", "foo", str(script)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cbatch.main()
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "Error:" in err


### PR DESCRIPTION
## Summary
- Ensure cbatch exits using the FileNotFoundError's errno (defaulting to 1) and prints the error message to stderr
- Add regression test for FileNotFoundError ensuring proper exit code and stderr output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932d81ef808329b11e1f43954ce48e

## Summary by Sourcery

Handle FileNotFoundError in cbatch by exiting with its errno (or 1 if unspecified) and printing the error to stderr, and add a regression test for this behavior

Bug Fixes:
- Exit with the FileNotFoundError errno (or default to 1) and print the error message to stderr when a file is not found in cbatch

Tests:
- Add a regression test to verify that FileNotFoundError triggers the correct exit code and stderr output