### PR TITLE
Gracefully handle errors opening job scripts

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -16,11 +16,15 @@ PYTHON_ENV_MNGR = 'conda'
 def extract_sbatch_tokens(script_path):
     '''Extract all tokens from #SBATCH lines in a Slurm job script.'''
     tokens = []
-    with open(script_path) as script_file:
-        for line in script_file:
-            line = line.strip()
-            if line.startswith("#SBATCH"):
-                tokens.extend(shlex.split(line[len("#SBATCH"):].strip()))
+    try:
+        with open(script_path) as script_file:
+            for line in script_file:
+                line = line.strip()
+                if line.startswith("#SBATCH"):
+                    tokens.extend(shlex.split(line[len("#SBATCH"):].strip()))
+    except OSError as e:
+        print(f"Error reading job script '{script_path}': {e}", file=sys.stderr)
+        raise
     return tokens
 
 def stream(input_stream, output_stream):


### PR DESCRIPTION
## Summary
- handle OSError when reading job script by printing a descriptive message

## Testing
- `python -m py_compile src/cbatch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932de8ac348329b64e6712d351c044

## Summary by Sourcery

Bug Fixes:
- Add try/except around file open in extract_sbatch_tokens to catch OSError and emit an error message.