### PR TITLE
Ensure bash invocation and portable redirection

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -120,7 +120,7 @@ def main():
         args.export = 'ALL'
 
     # Command to ensure the environment is clean
-    clean_command = 'module purge &> /dev/null'
+    clean_command = 'module purge > /dev/null 2>&1'
     if not args.quiet:
         clean_command = '(>&2 echo "Cleaning environment...") && ' + clean_command
 
@@ -169,6 +169,7 @@ def main():
             text=True,
             shell=True,
             bufsize=1,
+            executable='/bin/bash'
         )
         threading.Thread(target=stream, args=(process.stdout, sys.stdout), daemon=True).start()
         threading.Thread(target=stream, args=(process.stderr, sys.stderr), daemon=True).start()


### PR DESCRIPTION
## Summary
- ensure `cbatch` always uses Bash by specifying `executable='/bin/bash'` in `subprocess.Popen`
- replace `&>` redirection with portable `> /dev/null 2>&1`

## Testing
- `pytest -q`
- `python3 src/cbatch.py --cluster test --dry-run jobscripts/jobscript.slurm`


------
https://chatgpt.com/codex/tasks/task_e_689336ee6b908329a352bdd453d57622

## Summary by Sourcery

Ensure the cbatch script consistently uses Bash for shell invocations and employ portable output redirection to maintain compatibility across environments.

Enhancements:
- Force subprocess to use Bash by specifying executable='/bin/bash'
- Replace non-portable '&>' redirection with '> /dev/null 2>&1' for compatibility