### PR TITLE
Fix typo in export argument help

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -46,7 +46,7 @@ def main():
     )
     script_parser.add_argument(
         '--export',
-        help='Environment variabels to export to the job.'
+        help='Environment variables to export to the job.'
     )
 
     # Define the parser for the command line arguments.  It cares about


### PR DESCRIPTION
## Summary
- Correct the `--export` argument help text typo from "variabels" to "variables".

## Testing
- `python src/cbatch.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932df88bfc8329a5f0486b9e81e30a

## Summary by Sourcery

Documentation:
- Correct typo in --export argument help text from 'variabels' to 'variables'.