### PR TITLE
Join stream threads after process completion

### DIFF
--- a/src/cbatch.py
+++ b/src/cbatch.py
@@ -170,9 +170,17 @@ def main():
             shell=True,
             bufsize=1,
         )
-        threading.Thread(target=stream, args=(process.stdout, sys.stdout), daemon=True).start()
-        threading.Thread(target=stream, args=(process.stderr, sys.stderr), daemon=True).start()
+        stdout_thread = threading.Thread(
+            target=stream, args=(process.stdout, sys.stdout)
+        )
+        stderr_thread = threading.Thread(
+            target=stream, args=(process.stderr, sys.stderr)
+        )
+        stdout_thread.start()
+        stderr_thread.start()
         exit_status = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
         sys.exit(exit_status)
     except FileNotFoundError as e:
         print(f'Error: {e}', file=sys.stderr)


### PR DESCRIPTION
## Summary
- ensure stdout and stderr streaming threads are joined before exiting to avoid truncated output

## Testing
- `pytest -q`
- `python -m py_compile src/cbatch.py`


------
https://chatgpt.com/codex/tasks/task_e_68932dedd5e083298e8957ac4df00852

## Summary by Sourcery

Enhancements:
- Start stdout and stderr streaming threads as non-daemon and join them after process completion